### PR TITLE
feat: implement link_set_master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lnwasi"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 authors = ["Wongyu Lee <wq.lee@samsung.com>"]
 description = "Netlink Library for Web Assembly"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,38 @@ and exposes a high level API for interacting with the kernel's netlink interface
 similarly to the `iproute2` command line tool.
 Ultimately, the goal is to make the library available in a **web assembly** environment as well.
 
+## Examples
+
+Add a new dummy link and modify its name:
+
+```rust
+use anyhow::Result;
+use lnwasi::{
+    link::{Kind, Link, LinkAttrs},
+    netlink::Netlink,
+};
+
+fn main() {
+    let mut netlink = Netlink::new().unwrap();
+
+    let dummy = Kind::Dummy(LinkAttrs {
+        name: "foo".to_string(),
+        ..Default::default()
+    });
+
+    netlink.link_add(&dummy).unwrap();
+
+    let mut link = netlink.link_get(dummy.attrs()).unwrap();
+
+    link.attrs_mut().name = "bar".to_string();
+    netlink.link_modify(&link).unwrap();
+
+    let link = netlink.link_get(link.attrs()).unwrap();
+
+    netlink.link_del(&link).unwrap();
+}
+```
+
 ## Supported commands
 
 ### Link

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -315,9 +315,6 @@ mod tests {
         attr.num_rx_queues = 8;
         attr.master_index = master_index;
 
-        // [40 0 0 0 19 0 5 0 8 0 0 0 0 0 0 0 0 0 0 0 4 0 0 0 0 0 0 0 0 0 0 0 8 0 10 0 2 0 0 0]
-        // [40 0 0 0 19 0 5 0 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 8 0 10 0 2 0 0 0]
-
         // TODO: need to set peer hw addr and peer ns
         let link = Kind::Veth {
             attrs: attr.clone(),

--- a/src/link.rs
+++ b/src/link.rs
@@ -568,10 +568,26 @@ pub fn link_setup(index: i32) -> Result<NetlinkRequest> {
     let mut req = NetlinkRequest::new(libc::RTM_NEWLINK, libc::NLM_F_ACK);
     let mut msg = Box::new(InfoMessage::new(libc::AF_UNSPEC));
     msg.index = index;
-    msg.flags = 1;
-    msg.change = 1;
+    msg.flags = libc::IFF_UP as u32;
+    msg.change = libc::IFF_UP as u32;
 
     req.add_data(msg);
+
+    Ok(req)
+}
+
+pub fn link_set_master(index: i32, master: i32) -> Result<NetlinkRequest> {
+    let mut req = NetlinkRequest::new(libc::RTM_SETLINK, libc::NLM_F_ACK);
+    let mut msg = Box::new(InfoMessage::new(libc::AF_UNSPEC));
+    msg.index = index;
+
+    let mut b = [0; 4];
+    b.copy_from_slice(&master.to_ne_bytes());
+
+    let data = Box::new(NetlinkRouteAttr::new(libc::IFLA_MASTER, b.to_vec()));
+
+    req.add_data(msg);
+    req.add_data(data);
 
     Ok(req)
 }


### PR DESCRIPTION
If master_index is set in LinkAttrs, add the `IFLA_MASTER` attribute to the netlink message.